### PR TITLE
fix redis cache set function

### DIFF
--- a/src/redis-cache.ts
+++ b/src/redis-cache.ts
@@ -34,10 +34,10 @@ const RedisCache = ({ client }: IRedisCacheOptions): IYokeCacheDriver => {
       milliseconds?: number,
     ): Promise<void> => {
       if (milliseconds) {
-        const seconds = milliseconds / 1000
+        const seconds = Math.floor(milliseconds / 1000)
         await setExAsync(key, seconds, value)
-      }
-
+        return
+      } 
       await setAsync(key, value)
     },
 


### PR DESCRIPTION
1. ttl cannot be a non-integer
2. set function of redis client should be invoked only once, or the `milliseconds` will not work as expected